### PR TITLE
Fix user build for OpenBMC

### DIFF
--- a/compile/compile.go
+++ b/compile/compile.go
@@ -65,7 +65,7 @@ func home(w http.ResponseWriter, r *http.Request) {
 		case "getBMCFirmware":
                       login := tail[1:]
                         // We must retreive the username BIOS and return it as the response body
-                        if ( ttydCommandlinuxboot != nil ) {
+                        if ( ttydCommandopenbmc != nil ) {
                                 unix.Kill(ttydCommandopenbmc.Process.Pid, unix.SIGINT)
                         }
                         f, _ := os.Open(firmwaresPath+"/test_openbmc_"+login+".mtd")

--- a/compile/startOpenBMCBuildWrapper
+++ b/compile/startOpenBMCBuildWrapper
@@ -1,2 +1,14 @@
 #!/bin/bash
-$BINARIES_PATH/ttyd -p 7682 -s 9 screen $BINARIES_PATH/startOpenBMCBuild "$@"
+function exitWrapper()
+{
+	kill -SIGINT $ttydPID
+	screen -ls | grep pts | cut -d. -f1 | awk '{print $1}' | xargs kill
+	exit 0
+}
+trap exitWrapper SIGINT
+$BINARIES_PATH/ttyd -p 7682 -s 9 screen $BINARIES_PATH/startOpenBMCBuild "$@"  &
+ttydPID=$!
+while true
+do
+	sleep 1
+done


### PR DESCRIPTION
When multiple users were using the platform the previous build kept some process running (like screen command) and interfere with the new build

Signed-off-by: vejmarie <jean-marie.verdun@hpe.com>