### PR TITLE
Enhance OpenBMC build cleanup by ensuring that the docker image

### DIFF
--- a/compile/startOpenBMCBuildWrapper
+++ b/compile/startOpenBMCBuildWrapper
@@ -1,6 +1,8 @@
 #!/bin/bash
+export USER=$1
 function exitWrapper()
 {
+	docker container kill openbmc_$USER
 	kill -SIGINT $ttydPID
 	screen -ls | grep pts | cut -d. -f1 | awk '{print $1}' | xargs kill
 	exit 0


### PR DESCRIPTION
is killed even if the user is requesting a new build during a current
one

Signed-off-by: vejmarie <jean-marie.verdun@hpe.com>