### PR TITLE
Fix a messy situation where loading newly build openbmc was killing a

### DIFF
--- a/compile/startLinuxbootBuildWrapper
+++ b/compile/startLinuxbootBuildWrapper
@@ -4,7 +4,16 @@ function exitWrapper()
 {
         docker container kill linuxboot_$USER
         kill -SIGINT $ttydPID
-        screen -ls | grep pts | cut -d. -f1 | awk '{print $1}' | xargs kill
+	active_screen=`screen -ls | grep pts | cut -d. -f1 | awk '{print $1}'`
+	for i in $active_screen
+	do
+		launcher=`cat /proc/$i/cmdline | tr '\000' ' ' | awk '{print $2}'`
+		if [ "$launcher" == "$BINARIES_PATH/startLinuxbootBuild" ]
+		then
+			kill -9 $i
+		fi
+	done
+#        screen -ls | grep pts | cut -d. -f1 | awk '{print $1}' | xargs kill
         exit 0
 }
 trap exitWrapper SIGINT

--- a/compile/startOpenBMCBuildWrapper
+++ b/compile/startOpenBMCBuildWrapper
@@ -4,7 +4,15 @@ function exitWrapper()
 {
 	docker container kill openbmc_$USER
 	kill -SIGINT $ttydPID
-	screen -ls | grep pts | cut -d. -f1 | awk '{print $1}' | xargs kill
+        for i in $active_screen
+        do
+                launcher=`cat /proc/$i/cmdline | tr '\000' ' ' | awk '{print $2}'`
+                if [ "$launcher" == "$BINARIES_PATH/startOpenBMCBuild" ]
+                then
+                        kill -9 $i
+                fi
+        done
+#	screen -ls | grep pts | cut -d. -f1 | awk '{print $1}' | xargs kill
 	exit 0
 }
 trap exitWrapper SIGINT


### PR DESCRIPTION
potential concurrent linuxboot build because of miss interpretation
of the running screen command

Signed-off-by: vejmarie <jean-marie.verdun@hpe.com>