### PR TITLE
Switch openbmc logging to verbose when running a non interactive build

### DIFF
--- a/compile/build_openbmc
+++ b/compile/build_openbmc
@@ -13,5 +13,10 @@ export SSTATE_DIR=/datas/SSTATE
 . ./setup $RECIPES
 echo "SSTATE_DIR ?= \"/datas/SSTATE\"" >> conf/local.conf
 echo "DL_DIR ?= \"/datas/dl\"" >> conf/local.conf
+if [ "$INTERACTIVE" != "0" ]
+then
 bitbake obmc-phosphor-image
+else
+bitbake -v obmc-phosphor-image
+fi
 cp tmp/deploy/images/dl360poc/obmc-phosphor-image-dl360poc-*.static.mtd /volume/obmc-dl360poc.static.mtd

--- a/compile/startOpenBMCBuild
+++ b/compile/startOpenBMCBuild
@@ -17,7 +17,7 @@ mkdir /tmp/volume/openbmc_$USERNAME
 else
 rm -rf /tmp/volume/openbmc_$USERNAME/*
 fi
-docker run -d --name openbmc_$SUM -v /datas:/datas -v /tmp/volume/openbmc_$USERNAME:/volume -e RECIPES=$RECIPES -e GITHUBREPO=$GITHUBREPO -e BRANCH=$BRANCH -e PROXY=$PROXY --rm=true  -t openbmc
+docker run -d --name openbmc_$SUM -v /datas:/datas -v /tmp/volume/openbmc_$USERNAME:/volume -e RECIPES=$RECIPES -e GITHUBREPO=$GITHUBREPO -e BRANCH=$BRANCH -e PROXY=$PROXY -e INTERACTIVE=$INTERACTIVE --rm=true  -t openbmc
 docker logs -f openbmc_$SUM
 docker wait openbmc_$SUM
 if [ -f /tmp/volume/openbmc_$USERNAME/obmc-dl360poc.static.mtd ]


### PR DESCRIPTION
Signed-off-by: vejmarie <jean-marie.verdun@hpe.com>